### PR TITLE
Ensure UTF-8 encoding for C# and Razor files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{cs,cshtml}]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure UTF-8 encoding for C# and Razor files
+*.cs     text working-tree-encoding=UTF-8
+*.cshtml text working-tree-encoding=UTF-8
+

--- a/Pages/Auth/Callback.cshtml
+++ b/Pages/Auth/Callback.cshtml
@@ -1,26 +1,26 @@
-﻿@page
+@page
 @model IvaFacilitador.Pages.Auth.CallbackModel
 @{
-    ViewData["Title"]="ConexiÃ³n completada";
+    ViewData["Title"]="Conexión completada";
     Layout="/Pages/Shared/_Layout.cshtml";
 }
 <div class="row justify-content-center">
   <div class="col-lg-8">
     <div class="card shadow-sm card-iva">
       <div class="card-body p-4">
-        <h1 class="h4 mb-3">ConexiÃ³n completada</h1>
+        <h1 class="h4 mb-3">Conexión completada</h1>
 
         @if(!string.IsNullOrEmpty(Model.Error)){
           <div class="alert alert-danger">@Model.Error</div>
         } else {
           <div class="alert alert-success">
-            <div><strong>Â¡Listo!</strong> Empresa conectada:</div>
+            <div><strong>¡Listo!</strong> Empresa conectada:</div>
             <div class="mt-2">
               <span class="fw-semibold">@Model.CompanyName</span>
               <span class="text-muted">(@Model.RealmId)</span>
             </div>
           </div>
-          <a class="btn btn-acento" href="/IVA/Seleccion">Continuar a CÃ¡lculo de IVA</a>
+          <a class="btn btn-acento" href="/IVA/Seleccion">Continuar a Cálculo de IVA</a>
         }
       </div>
     </div>

--- a/Pages/Auth/Connect.cshtml
+++ b/Pages/Auth/Connect.cshtml
@@ -1,9 +1,9 @@
-﻿@page
+@page
 @model IvaFacilitador.Pages.Auth.ConnectModel
 @{ ViewData["Title"]="Conectar QuickBooks"; Layout="/Pages/Shared/_Layout.cshtml"; }
 <div class="row justify-content-center"><div class="col-lg-8"><div class="card shadow-sm card-iva">
 <div class="card-body p-4"><h1 class="h4 mb-3">Conectar con QuickBooks</h1>
-<p class="text-secondary">Pulsa el botÃ³n para autorizar el acceso. SerÃ¡s redirigido a Intuit.</p>
+<p class="text-secondary">Pulsa el botón para autorizar el acceso. Serás redirigido a Intuit.</p>
 <a class="btn btn-primary" href="/Auth/Start">Conectar con QuickBooks</a>
 <a class="btn btn-outline-secondary" href="/IVA/Seleccion">Volver</a></div></div></div></div>
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Authorization;
@@ -15,7 +15,7 @@ builder.Services.AddRazorPages(options =>
 {
     // Por defecto, todo requiere login
     options.Conventions.AuthorizeFolder("/");
-    // Permitir pÃ¡ginas de autenticaciÃ³n y callback de Intuit sin login previo
+    // Permitir páginas de autenticación y callback de Intuit sin login previo
     options.Conventions.AllowAnonymousToPage("/Auth/Login");
     options.Conventions.AllowAnonymousToPage("/Auth/Callback");
 });


### PR DESCRIPTION
## Summary
- fix misencoded Spanish strings in Razor views and program comment
- add .editorconfig to enforce UTF-8 for C# and Razor files
- add .gitattributes to keep *.cs and *.cshtml UTF-8 encoded

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_689f74bb57c08332aa9829bdfbb686b2