### PR TITLE
Fix encoding in auth callback page

### DIFF
--- a/Pages/Auth/Callback.cshtml
+++ b/Pages/Auth/Callback.cshtml
@@ -1,26 +1,26 @@
 ﻿@page
 @model IvaFacilitador.Pages.Auth.CallbackModel
 @{
-    ViewData["Title"]="ConexiÃ³n completada";
+    ViewData["Title"]="Conexión completada";
     Layout="/Pages/Shared/_Layout.cshtml";
 }
 <div class="row justify-content-center">
   <div class="col-lg-8">
     <div class="card shadow-sm card-iva">
       <div class="card-body p-4">
-        <h1 class="h4 mb-3">ConexiÃ³n completada</h1>
+        <h1 class="h4 mb-3">Conexión completada</h1>
 
         @if(!string.IsNullOrEmpty(Model.Error)){
           <div class="alert alert-danger">@Model.Error</div>
         } else {
           <div class="alert alert-success">
-            <div><strong>Â¡Listo!</strong> Empresa conectada:</div>
+            <div><strong>¡Listo!</strong> Empresa conectada:</div>
             <div class="mt-2">
               <span class="fw-semibold">@Model.CompanyName</span>
               <span class="text-muted">(@Model.RealmId)</span>
             </div>
           </div>
-          <a class="btn btn-acento" href="/IVA/Seleccion">Continuar a CÃ¡lculo de IVA</a>
+          <a class="btn btn-acento" href="/IVA/Seleccion">Continuar a Cálculo de IVA</a>
         }
       </div>
     </div>


### PR DESCRIPTION
## Summary
- correct accent characters on auth callback page

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689f753699908332b67865028b2ae301