### PR TITLE
Ensure FileTokenStore reads are thread-safe

### DIFF
--- a/Services/TokenModels.cs
+++ b/Services/TokenModels.cs
@@ -48,10 +48,13 @@ namespace IvaFacilitador.Services
 
         public TokenResponse? Get(string realmId)
         {
-            var path = Path.Combine(_folder, $"token_{realmId}.json");
-            if (!File.Exists(path)) return null;
-            var json = File.ReadAllText(path);
-            return System.Text.Json.JsonSerializer.Deserialize<TokenResponse>(json);
+            lock (_lock)
+            {
+                var path = Path.Combine(_folder, $"token_{realmId}.json");
+                if (!File.Exists(path)) return null;
+                var json = File.ReadAllText(path);
+                return System.Text.Json.JsonSerializer.Deserialize<TokenResponse>(json);
+            }
         }
 
         public void Delete(string realmId) // ← NUEVO


### PR DESCRIPTION
## Summary
- protect token retrieval with a lock to avoid concurrent file access issues

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689f74197290833293b8ac8e7dadcccd