### PR TITLE
Convert OnboardQuick to partial and retain overlay script

### DIFF
--- a/Pages/Shared/Onboarding/_OnboardQuick.cshtml
+++ b/Pages/Shared/Onboarding/_OnboardQuick.cshtml
@@ -1,4 +1,3 @@
-@page
 @* Overlay para parametrizar rápidamente la empresa *@
 <div id="onb-overlay" class="onb-overlay" style="display:none;">
   <div class="onb-modal card shadow">
@@ -22,7 +21,6 @@
   </div>
 </div>
 
-@section Scripts {
 <script>
 (function(){
   function getCookie(n){
@@ -44,4 +42,3 @@
   }
 })();
 </script>
-}


### PR DESCRIPTION
## Summary
- Convert `_OnboardQuick.cshtml` into a partial view and keep its overlay script inline for cookie-driven onboarding logic.

## Testing
- `dotnet build`
- `node` (jsdom) loading `_OnboardQuick` with `onb_company` cookie to ensure overlay displays and no console errors


------
https://chatgpt.com/codex/tasks/task_b_689fa024b1ac83328fc7d41fcba5170e